### PR TITLE
Deprecated Rails 5.1

### DIFF
--- a/app/controllers/redsys/tpv_controller.rb
+++ b/app/controllers/redsys/tpv_controller.rb
@@ -1,6 +1,6 @@
 module Redsys
   class TpvController < ApplicationController
-    skip_before_filter :verify_authenticity_token, only: [:confirmation]
+    skip_before_action :verify_authenticity_token, only: [:confirmation]
 
     #
     # Formulario de salto a la pasarela de pago


### PR DESCRIPTION
I've changed skip_before_filter to skip_before_action. It will be deprecated in Rails 5.1